### PR TITLE
fix: stable SwiftUI pin input layout, selection and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,93 @@ Clone the repo and drag files from `NerdzPinView/Sources` folder into your Xcode
 
 ### SwiftUI
 
-NerdzPinView library provides complete SwiftUI wrapper over custom UIKeyInput component. To use it inside your SwiftUI application just add `NerdzBorderedPinView` or `NerdzUnderlinePinView` inside your view body.
-SwiftUI views have `text`, `viewState`, and `isFocused` binding properties alongside UIKeyInput properties that are passed to the wrapped view. 
+NerdzPinView provides ready to use SwiftUI wrappers over the underlying `UIKeyInput` component. Drop `NerdzBorderedPinView` or `NerdzUnderlinePinView` into your view body and bind the text, view state, and focus state. A typical setup looks like the snippet below.
 
-You could take a look into the usage of the library inside SwiftUI project using [SwiftUI demo project](https://github.com/RomanKovalchukDev/NerdzPinView/tree/main/Samples/NerdzPinSwiftUISample).
+```swift
+import SwiftUI
+import NerdzPinView
+
+struct LoginView: View {
+    @State private var code: String = ""
+    @State private var viewState: NerdzBorderedPinView.ViewState = .normal
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        NerdzBorderedPinView(
+            text: $code,
+            viewState: $viewState,
+            isFocused: $isFocused,
+            onPinViewEnteredFully: { value in
+                submit(code: value)
+            }
+        )
+        .frame(height: 50)
+        .padding(.horizontal)
+    }
+}
+```
+
+`NerdzBorderedPinView` and `NerdzUnderlinePinView` share the same public surface. The most important pieces are:
+
+* `text: Binding<String>` receives every keystroke and lets you drive the view from external state (for example to clear it after a failed verification).
+* `viewState: Binding<ViewState>` controls the visual state (`.normal`, `.error`, `.disabled`).
+* `isFocused: FocusState<Bool>.Binding` lets SwiftUI manage the keyboard the same way it does for `TextField`.
+* `onPinViewEnteredFully: ((String) -> Void)?` fires once the user has typed `config.pinLength` characters.
+
+All of the `UIKeyInput` configuration (keyboard type, autocorrection, content type, secure entry, etc.) is exposed as initializer parameters with sensible defaults.
+
+You can also browse the [SwiftUI demo project](https://github.com/RomanKovalchukDev/NerdzPinView/tree/main/Samples/NerdzPinSwiftUISample).
+
+### Configuration
+
+Each view accepts three configuration objects, all of them plain Swift structs. Every property in their initializers has a default value, so you can override only the ones you care about and leave the rest at the library defaults.
+
+```swift
+NerdzBorderedPinView(
+    text: $code,
+    viewState: $viewState,
+    isFocused: $isFocused,
+    config: .init(
+        pinLength: 6,
+        isContentCentered: true,
+        containerSpacing: 12
+    ),
+    itemsLayoutConfig: .init(cornerRadius: 12),
+    itemsAppearanceConfig: .init(
+        defaultBackgroundColor: .systemGray6,
+        activeBorderColor: .systemBlue,
+        errorBorderColor: .systemRed,
+        cursorColor: .label,
+        font: .systemFont(ofSize: 18, weight: .semibold)
+    )
+)
+```
+
+The three configs are:
+
+* `PinViewConfig` (top level) covers behavior: pin length, placeholder character, secure text presentation, paste handling, layout policy (`isContentCentered`, `containerSpacing`), delete behavior, and whether the field should resign first responder on completion or return.
+* `LayoutConfig` (per item) covers geometry: corner radius, cursor size, content insets.
+* `AppearanceConfig` (per item) covers colors and the font, with separate slots for the `.normal`, `.active`, and `.error` states. Any state specific color left as `nil` falls back to the default color, so you can light up only the states you care about.
+
+If you want a single property changed on top of an existing config, you can also build it from an existing value using normal Swift struct copy semantics:
+
+```swift
+var appearance = BorderedItemView.AppearanceConfig.defaultValue
+appearance.activeBorderColor = .systemBlue
+appearance.cursorColor = .systemBlue
+```
+
+### Layout sizing
+
+The items are always rendered as squares, sized to the height of the view. The view will fit `pinLength` squares plus `containerSpacing * (pinLength - 1)` of horizontal space at the current height. Apply a `.frame(height:)` (or any equivalent height constraint) and make sure the available width can hold that many squares. If the width is tighter, the items shrink uniformly and stay centered.
 
 ### UIKit
 
-To use the library from the xib files or storyboards you should use `DesignableBorderedPinInputView` or `DesignableUnderlinedPinInputView` - this two classes are predefined views that are wrapers around generic `PinCodeInputView`.
+For storyboards and xibs, use the prebuilt `DesignableBorderedPinInputView` or `DesignableUnderlinedPinInputView`. They wrap the same generic `PinCodeInputView` used by the SwiftUI components and expose the same configuration objects (`config`, `layoutConfig`, `appearanceConfig`) as settable properties.
 
-You could also use generic `PinCodeInputView` programatically. This use case mostly needed for you to provide your own item display view. 
+For full control (for example to plug in a custom item view), use the generic `PinCodeInputView<T: PinCodeItemView>` directly. Implement `PinCodeItemViewType`, `ItemViewLayoutConfigurable`, and `ItemViewAppearanceConfigurable` on your custom item to participate in the same configuration pipeline.
 
-You could take a look into the usage of the library inside SwiftUI project using [SwiftUI demo project](https://github.com/RomanKovalchukDev/NerdzPinView/tree/main/Samples//NerdzPinUIKitSample).
+You can also browse the [UIKit demo project](https://github.com/RomanKovalchukDev/NerdzPinView/tree/main/Samples/NerdzPinUIKitSample).
 
 ## Requirements
 

--- a/Samples/NerdzPinSwiftUISample/.claude/settings.local.json
+++ b/Samples/NerdzPinSwiftUISample/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__XcodeBuildMCP__discover_projs",
+      "mcp__XcodeBuildMCP__build_sim"
+    ]
+  }
+}

--- a/Samples/NerdzPinSwiftUISample/NerdzPinSwiftUISample.xcodeproj/project.pbxproj
+++ b/Samples/NerdzPinSwiftUISample/NerdzPinSwiftUISample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3078D6B82FBF3CF000048656 /* NerdzPinView in Frameworks */ = {isa = PBXBuildFile; productRef = 3078D6B72FBF3CF000048656 /* NerdzPinView */; };
 		B07E12B02D1090F000194E64 /* NerdzPinView in Frameworks */ = {isa = PBXBuildFile; productRef = B07E12AF2D1090F000194E64 /* NerdzPinView */; };
 /* End PBXBuildFile section */
 
@@ -28,6 +29,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B07E12B02D1090F000194E64 /* NerdzPinView in Frameworks */,
+				3078D6B82FBF3CF000048656 /* NerdzPinView in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,6 +73,7 @@
 			name = NerdzPinSwiftUISample;
 			packageProductDependencies = (
 				B07E12AF2D1090F000194E64 /* NerdzPinView */,
+				3078D6B72FBF3CF000048656 /* NerdzPinView */,
 			);
 			productName = NerdzPinSwiftUISample;
 			productReference = B07E12942D108EE100194E64 /* NerdzPinSwiftUISample.app */;
@@ -101,7 +104,7 @@
 			mainGroup = B07E128B2D108EE100194E64;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				B07E12AE2D1090F000194E64 /* XCLocalSwiftPackageReference "../../NerdzPinView" */,
+				3078D6B62FBF3CF000048656 /* XCLocalSwiftPackageReference "../../../NerdzPinView" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = B07E12952D108EE100194E64 /* Products */;
@@ -335,13 +338,17 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		B07E12AE2D1090F000194E64 /* XCLocalSwiftPackageReference "../../NerdzPinView" */ = {
+		3078D6B62FBF3CF000048656 /* XCLocalSwiftPackageReference "../../../NerdzPinView" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../NerdzPinView;
+			relativePath = ../../../NerdzPinView;
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3078D6B72FBF3CF000048656 /* NerdzPinView */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = NerdzPinView;
+		};
 		B07E12AF2D1090F000194E64 /* NerdzPinView */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NerdzPinView;

--- a/Samples/NerdzPinSwiftUISample/NerdzPinSwiftUISample/ContentView.swift
+++ b/Samples/NerdzPinSwiftUISample/NerdzPinSwiftUISample/ContentView.swift
@@ -31,10 +31,6 @@ struct ContentView: View {
             
             Text("Text for the second field \(text2)")
             
-            NerdzUnderlinePinView(text: $text2)
-                .frame(height: 50)
-                .padding()
-            
             Button(
                 action: {
                     debugPrint(text)

--- a/Sources/NerdzPinView/SwiftUI/NerdzBorderedPinView.swift
+++ b/Sources/NerdzPinView/SwiftUI/NerdzBorderedPinView.swift
@@ -106,6 +106,10 @@ public struct NerdzBorderedPinView: UIViewRepresentable {
     
     private func updateKitView(view: DesignableBorderedPinInputView) {
         view.setText(text)
+        view.viewState = viewState
+        view.config = config
+        view.layoutConfig = itemsLayutConfig
+        view.appearanceConfig = itemsAppearanceConfig
         view.autocapitalizationType = autocapitalizationType
         view.autocorrectionType = autocorrectionType
         view.spellCheckingType = spellCheckingType

--- a/Sources/NerdzPinView/SwiftUI/NerdzBorderedPinView.swift
+++ b/Sources/NerdzPinView/SwiftUI/NerdzBorderedPinView.swift
@@ -32,7 +32,7 @@ public struct NerdzBorderedPinView: UIViewRepresentable {
     public var textContentType: UITextContentType!
 
     private let config: ViewConfig
-    private let itemsLayutConfig: BorderedItemView.LayoutConfig
+    private let itemsLayoutConfig: BorderedItemView.LayoutConfig
     private let itemsAppearanceConfig: BorderedItemView.AppearanceConfig
     
     public init(
@@ -53,7 +53,7 @@ public struct NerdzBorderedPinView: UIViewRepresentable {
         isSecureTextEntry: Bool = false,
         textContentType: UITextContentType! = .oneTimeCode,
         config: ViewConfig = .init(),
-        itemsLayutConfig: BorderedItemView.LayoutConfig = .defaultValue,
+        itemsLayoutConfig: BorderedItemView.LayoutConfig = .defaultValue,
         itemsAppearanceConfig: BorderedItemView.AppearanceConfig = .defaultValue
     ) {
         self._text = text
@@ -73,7 +73,7 @@ public struct NerdzBorderedPinView: UIViewRepresentable {
         self.isSecureTextEntry = isSecureTextEntry
         self.textContentType = textContentType
         self.config = config
-        self.itemsLayutConfig = itemsLayutConfig
+        self.itemsLayoutConfig = itemsLayoutConfig
         self.itemsAppearanceConfig = itemsAppearanceConfig
     }
     
@@ -108,7 +108,7 @@ public struct NerdzBorderedPinView: UIViewRepresentable {
         view.setText(text)
         view.viewState = viewState
         view.config = config
-        view.layoutConfig = itemsLayutConfig
+        view.layoutConfig = itemsLayoutConfig
         view.appearanceConfig = itemsAppearanceConfig
         view.autocapitalizationType = autocapitalizationType
         view.autocorrectionType = autocorrectionType

--- a/Sources/NerdzPinView/SwiftUI/NerdzUnderlinePinView.swift
+++ b/Sources/NerdzPinView/SwiftUI/NerdzUnderlinePinView.swift
@@ -106,7 +106,11 @@ public struct NerdzUnderlinePinView: UIViewRepresentable {
     
     private func updateKitView(view: DesignableUnderlinedPinInputView) {
         view.setText(text)
-        
+        view.viewState = viewState
+        view.config = config
+        view.layoutConfig = itemsLayutConfig
+        view.appearanceConfig = itemsAppearanceConfig
+
         view.autocapitalizationType = autocapitalizationType
         view.autocorrectionType = autocorrectionType
         view.spellCheckingType = spellCheckingType

--- a/Sources/NerdzPinView/SwiftUI/NerdzUnderlinePinView.swift
+++ b/Sources/NerdzPinView/SwiftUI/NerdzUnderlinePinView.swift
@@ -32,7 +32,7 @@ public struct NerdzUnderlinePinView: UIViewRepresentable {
     public var textContentType: UITextContentType!
     
     private let config: DesignableUnderlinedPinInputView.PinViewType.PinViewConfig
-    private let itemsLayutConfig: UnderlineItemView.LayoutConfig
+    private let itemsLayoutConfig: UnderlineItemView.LayoutConfig
     private let itemsAppearanceConfig: UnderlineItemView.AppearanceConfig
     
     public init(
@@ -53,7 +53,7 @@ public struct NerdzUnderlinePinView: UIViewRepresentable {
         isSecureTextEntry: Bool = false,
         textContentType: UITextContentType! = .oneTimeCode,
         config: ViewConfig = .init(),
-        itemsLayutConfig: UnderlineItemView.LayoutConfig = .defaultValue,
+        itemsLayoutConfig: UnderlineItemView.LayoutConfig = .defaultValue,
         itemsAppearanceConfig: UnderlineItemView.AppearanceConfig = .defaultValue
     ) {
         self._text = text
@@ -73,7 +73,7 @@ public struct NerdzUnderlinePinView: UIViewRepresentable {
         self.isSecureTextEntry = isSecureTextEntry
         self.textContentType = textContentType
         self.config = config
-        self.itemsLayutConfig = itemsLayutConfig
+        self.itemsLayoutConfig = itemsLayoutConfig
         self.itemsAppearanceConfig = itemsAppearanceConfig
     }
     
@@ -108,7 +108,7 @@ public struct NerdzUnderlinePinView: UIViewRepresentable {
         view.setText(text)
         view.viewState = viewState
         view.config = config
-        view.layoutConfig = itemsLayutConfig
+        view.layoutConfig = itemsLayoutConfig
         view.appearanceConfig = itemsAppearanceConfig
 
         view.autocapitalizationType = autocapitalizationType

--- a/Sources/NerdzPinView/Views/PinInputView/PinCodeInputView.swift
+++ b/Sources/NerdzPinView/Views/PinInputView/PinCodeInputView.swift
@@ -20,7 +20,7 @@ public class PinCodeInputView<T: PinCodeItemView>: UIView, UIKeyInput, @preconcu
         case error
     }
     
-    public struct PinViewConfig {
+    public struct PinViewConfig: Equatable {
         public var pinLength: Int
         public var placeholderCharacter: Character?
         
@@ -81,6 +81,7 @@ public class PinCodeInputView<T: PinCodeItemView>: UIView, UIKeyInput, @preconcu
     
     public var config: PinViewConfig = PinViewConfig() {
         didSet {
+            guard oldValue != config else { return }
             configureView()
         }
     }
@@ -130,6 +131,8 @@ public class PinCodeInputView<T: PinCodeItemView>: UIView, UIKeyInput, @preconcu
     
     private var activeItemIndex: Int?
     private var charactersArray: [Character?] = []
+    private var stackAnchorConstraints: [NSLayoutConstraint] = []
+    private var hasConfiguredHierarchy: Bool = false
     
     private var itemViews: [T] {
         containerStackView.arrangedSubviews.compactMap({ $0 as? T })
@@ -350,74 +353,118 @@ public class PinCodeInputView<T: PinCodeItemView>: UIView, UIKeyInput, @preconcu
     private func configureView() {
         initialViewLayout()
         configureSubviews()
-        containerStackView.addInteraction(editMenuInteraction)
-        longPressGestureRecognizer.minimumPressDuration = config.pasteGestureMinDuration
-        containerStackView.addGestureRecognizer(longPressGestureRecognizer)
     }
-    
+
     private func initialViewLayout() {
-        // Disable autoresizing mask translation for Auto Layout
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
 
-        // Remove any existing constraints on containerStackView
-        NSLayoutConstraint.deactivate(containerStackView.constraints)
+        // One-time hierarchy/setup. Re-running addSubview, addInteraction and
+        // addGestureRecognizer on every config change would otherwise stack up
+        // duplicate interactions and recognizers.
+        if !hasConfiguredHierarchy {
+            addSubview(containerStackView)
 
-        addSubview(containerStackView)
-        
-        // Pin containerStackView top and bottom to the view’s edges
-        NSLayoutConstraint.activate([
-            containerStackView.topAnchor.constraint(equalTo: topAnchor),
-            containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
-        
-        if config.isContentCentered {
-            containerStackView.distribution = .fill
-            containerStackView.spacing = config.containerSpacing
-            
-            // Center horizontally and allow flexible left/right constraints
+            containerStackView.axis = .horizontal
+            // Items are not forced to fill the cross axis — each item sizes itself
+            // via its own constraints (square + capped to the stack height) and is
+            // centered vertically when it has to shrink to fit the available width.
+            containerStackView.alignment = .center
+
+            containerStackView.addInteraction(editMenuInteraction)
+            containerStackView.addGestureRecognizer(longPressGestureRecognizer)
+
             NSLayoutConstraint.activate([
+                containerStackView.topAnchor.constraint(equalTo: topAnchor),
+                containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ])
+
+            hasConfiguredHierarchy = true
+        }
+
+        containerStackView.spacing = config.containerSpacing
+        // .equalSpacing in both branches keeps items at their natural square size
+        // and absorbs leftover horizontal space into the inter-item gaps. With
+        // .fill the stack would divide its width across N items, which can force
+        // each item wider than the stack is tall and break the 1:1 constraint.
+        containerStackView.distribution = .equalSpacing
+        longPressGestureRecognizer.minimumPressDuration = config.pasteGestureMinDuration
+
+        // Drop the previously installed horizontal anchors so that switching
+        // between centered / non-centered modes does not leave both sets active.
+        NSLayoutConstraint.deactivate(stackAnchorConstraints)
+        stackAnchorConstraints.removeAll()
+
+        if config.isContentCentered {
+            stackAnchorConstraints = [
                 containerStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
                 containerStackView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor),
                 containerStackView.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor)
-            ])
-        } else {
-            containerStackView.distribution = .equalSpacing
-            
-            // Pin left and right to the view’s edges
-            NSLayoutConstraint.activate([
+            ]
+        }
+        else {
+            stackAnchorConstraints = [
                 containerStackView.leftAnchor.constraint(equalTo: leftAnchor),
                 containerStackView.rightAnchor.constraint(equalTo: rightAnchor)
-            ])
+            ]
         }
+
+        NSLayoutConstraint.activate(stackAnchorConstraints)
     }
     
     private func configureSubviews() {
-        containerStackView.arrangedSubviews.forEach({ $0.removeFromSuperview() })
         charactersArray.removeAll()
-        
+        containerStackView.arrangedSubviews.forEach({ $0.removeFromSuperview() })
+
+        var firstItemView: T?
+
         for index in 0..<config.pinLength {
             let view = T()
-                        
+
             view.onViewTapped = { [weak self] in
-                self?.activeItemIndex = index
-                self?.becomeFirstResponder()
+                guard let self else {
+                    return
+                }
+
+                let firstEmpty = self.charactersArray.firstIndex(where: { $0 == nil }) ?? (self.config.pinLength - 1)
+                self.activeItemIndex = min(index, firstEmpty)
+                self.becomeFirstResponder()
             }
-            
+
             view.translatesAutoresizingMaskIntoConstraints = false
 
-            // Add width and height constraints to maintain a 1:1 aspect ratio
-            NSLayoutConstraint.activate([
-                view.heightAnchor.constraint(equalTo: view.widthAnchor)
-            ])
-            
             view.layoutConfig = layoutConfig
             view.appearanceConfig = appearanceConfig
             view.placeholderCharacter = config.placeholderCharacter
             view.secureTextCharacter = config.secureTextCharacter
             view.secureTextDelay = config.secureTextDelay
-                                                
+
             charactersArray.append(nil)
             containerStackView.addArrangedSubview(view)
+
+            // Square aspect, hard cap to stack height, and a high-priority preference
+            // to be exactly stack height. The preference bends when the available width
+            // can't fit N full-height squares, so constraints never become unsatisfiable.
+            let aspect = view.heightAnchor.constraint(equalTo: view.widthAnchor)
+            aspect.priority = .required
+
+            let heightCap = view.heightAnchor.constraint(lessThanOrEqualTo: containerStackView.heightAnchor)
+            heightCap.priority = .required
+
+            let preferredHeight = view.heightAnchor.constraint(equalTo: containerStackView.heightAnchor)
+            preferredHeight.priority = .defaultHigh
+
+            NSLayoutConstraint.activate([aspect, heightCap, preferredHeight])
+
+            // All items share the first item's width — keeps every cell identical
+            // and prevents the stack from handing leftover space to one cell.
+            if let firstItemView, view !== firstItemView {
+                let equalWidth = view.widthAnchor.constraint(equalTo: firstItemView.widthAnchor)
+                equalWidth.priority = .required
+                equalWidth.isActive = true
+            }
+            else {
+                firstItemView = view
+            }
         }
     }
     


### PR DESCRIPTION
## Summary

* Guard `PinViewConfig` `didSet` against no-op assignments so SwiftUI re-renders no longer wipe typed characters. Fixes `onPinViewEnteredFully` never firing.
* Make `PinCodeInputView`'s `initialViewLayout` idempotent: track horizontal stack anchors so switching `isContentCentered` does not leave both anchor sets active, and run the one-time hierarchy/interaction setup only once. Removes runtime constraint warnings and the `height == width` constraint breakage.
* Use `.equalSpacing` in both centered and non-centered branches, plus a required `height <= stack.height` cap and a `.defaultHigh` preferred-full-height constraint per item, so items stay square at stack height and excess width falls into the gaps rather than stretching one cell.
* Clamp tapped item selection to the first empty slot so users cannot focus a field past an unfilled one.
* Rename `itemsLayutConfig` to `itemsLayoutConfig` on `NerdzBorderedPinView` and `NerdzUnderlinePinView` (breaking change for existing callers).
* Expand README usage section with SwiftUI snippet, configuration overview, layout sizing notes, and UIKit pointers.